### PR TITLE
v0.5.1: Slight improvements to the sample world and maintenance updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout Local Repository
         uses: actions/checkout@v4
       - name: copy the README and LICENSE files to the Package folder
-        run: cp README.md LICENSE LICENSE.*.txt "${{ env.packagePath }}"
+        run: cp README.md README.*.md LICENSE LICENSE.*.txt "${{ env.packagePath }}"
       - id: version
         name: Get the Package version based on the package.json file
         # cspell: disable-next-line

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,10 @@
+ignores:
+  - .github/CODE_OF_CONDUCT*
+  - Assets/**/*
+  - Library/**/*
+  - Logs/**/*
+  - Packages/com.*/**/*
+  - Packages/dev.*/**/*
+  - ProjectSettings/**/*
+  - Temp/**/*
+  - UserSettings/**/*

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,17 @@
+default: true
+# Allow limit breakthroughs in the code block and table row lengths. The
+# default is unconditional prohibition. It is exceptionally allowed in
+# these elements due to folding difficulties.
+line-length:
+  code_blocks: false
+  tables: false
+# Allows the use of duplicate headings. The default is unconditional
+# prohibition. Due to the `siblings_only` flag not working, it is necessary
+# to enable duplicate headings in the entire document.
+no-duplicate-heading: false
+# Allows embedding of the specified HTML tag. The default is unconditional
+# prohibition. Allow for some valuable features, such as folding.
+no-inline-html:
+  allowed_elements:
+    - details
+    - summary

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "davidanson.vscode-markdownlint",
     "editorconfig.editorconfig",
     "fernandoescolar.vscode-solution-explorer",
     "redhat.vscode-yaml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,10 @@
     "*": "${capture}.meta, ${capture}.md5",
     "*.dll": "${capture}.pdb",
     "*.md": "${capture}.*.md",
+    "*.sln": "*.csproj",
     ".gitconfig": ".gitattributes, .gitignore",
     ".tool-versions": "global.json",
-    "*.sln": "*.csproj",
     "LICENSE": "LICENSE.*.txt",
-    "LICENSE*": "LICENSE${capture}.meta",
     "T.cs": "*.po"
   },
   "files.associations": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "*.md": "${capture}.*.md",
     "*.sln": "*.csproj",
     ".gitconfig": ".gitattributes, .gitignore",
+    ".markdownlint.*": ".markdownlint-cli2.*",
     ".tool-versions": "global.json",
     "LICENSE": "LICENSE.*.txt",
     "T.cs": "*.po"

--- a/Packages/black.kit.vrcui/Examples/Prefabs/Atoms/PanelsCatalog.prefab
+++ b/Packages/black.kit.vrcui/Examples/Prefabs/Atoms/PanelsCatalog.prefab
@@ -1112,6 +1112,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5750784664250184088}
     m_Modifications:
+    - target: {fileID: 597178341827600022, guid: 1705787b8dde7c74992ad927108f816b,
+        type: 3}
+      propertyPath: m_text
+      value: NAMEPLATE
+      objectReference: {fileID: 0}
     - target: {fileID: 2837934430366156194, guid: 1705787b8dde7c74992ad927108f816b,
         type: 3}
       propertyPath: m_Pivot.x

--- a/Packages/black.kit.vrcui/Examples/Prefabs/Common/CommonFloor.prefab
+++ b/Packages/black.kit.vrcui/Examples/Prefabs/Common/CommonFloor.prefab
@@ -64,7 +64,7 @@ Transform:
   m_GameObject: {fileID: 2083709199767625856}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 20, y: 0, z: 0}
   m_LocalScale: {x: 100, y: 100, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -529,6 +529,7 @@ MonoBehaviour:
     SerializedTypeNames: []
   portraitCameraPositionOffset: {x: 0, y: 0, z: 0}
   portraitCameraRotationOffset: {x: 0, y: 1, z: 0, w: -0.00000004371139}
+  NavigationAreas: []
 --- !u!114 &7906947851965477166
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Packages/black.kit.vrcui/Examples/Prefabs/Common/Portal.prefab
+++ b/Packages/black.kit.vrcui/Examples/Prefabs/Common/Portal.prefab
@@ -85,6 +85,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
+  - {fileID: 8821561487938681931}
   - {fileID: 6748599217821208633}
   - {fileID: 1403699155712108827}
   - {fileID: 857834883647961264}
@@ -173,6 +174,250 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1001 &3977087036345571136
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1302277527016175181}
+    m_Modifications:
+    - target: {fileID: 1055977790563140660, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055977790563140660, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055977790563140660, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055977790563140660, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055977790563140660, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1055977790563140660, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2554536543706324697, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_Name
+      value: Credit
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802518202563897116, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802518202563897116, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802518202563897116, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802518202563897116, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802518202563897116, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802518202563897116, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 198
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 98
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691650795544966797, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691650795544966797, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691650795544966797, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691650795544966797, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691650795544966797, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6691650795544966797, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7551971552889991200, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7551971552889991200, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7551971552889991200, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7551971552889991200, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7551971552889991200, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7551971552889991200, guid: c653335145d3c464ea4a2a10bd0261d5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c653335145d3c464ea4a2a10bd0261d5, type: 3}
+--- !u!224 &8821561487938681931 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5574621782765841163, guid: c653335145d3c464ea4a2a10bd0261d5,
+    type: 3}
+  m_PrefabInstance: {fileID: 3977087036345571136}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &9017124986269141352
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Packages/black.kit.vrcui/Examples/black.kit.vrcui.Examples.asmdef
+++ b/Packages/black.kit.vrcui/Examples/black.kit.vrcui.Examples.asmdef
@@ -2,6 +2,7 @@
     "name": "black.kit.vrcui.Examples",
     "rootNamespace": "black.kit.vrcui.Examples",
     "references": [
+        "Unity.TextMeshPro",
         "VRC.SDK3",
         "VRC.SDKBase",
         "VRC.Udon",

--- a/Packages/black.kit.vrcui/package.json
+++ b/Packages/black.kit.vrcui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "black.kit.vrcui",
   "displayName": "black.kit.vrcui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "unity": "2022.3",
   "unityRelease": "22f1",
   "description": "Unofficial uGUI theme like the LaunchPad for VRChat worlds. / 非公式のVRChat 風 uGUI スキン",

--- a/Packages/black.kit.vrcui/package.json
+++ b/Packages/black.kit.vrcui/package.json
@@ -24,8 +24,8 @@
   "dependencies": {},
   "gitDependencies": {},
   "vpmDependencies": {
-    "black.kit.launchpadicons": "^0.5.0",
-    "black.kit.toybox": "^0.7.0",
+    "black.kit.launchpadicons": "^0.6.0",
+    "black.kit.toybox": "^0.8.0",
     "com.vrchat.worlds": "^3.6.1"
   }
 }

--- a/Packages/vpm-manifest.json
+++ b/Packages/vpm-manifest.json
@@ -6,9 +6,6 @@
     "com.vrchat.core.vpm-resolver": {
       "version": "0.1.29"
     },
-    "black.kit.toybox": {
-      "version": "0.7.0"
-    },
     "com.vrchat.base": {
       "version": "3.6.1"
     },
@@ -16,7 +13,10 @@
       "version": "3.6.1"
     },
     "black.kit.launchpadicons": {
-      "version": "0.5.0"
+      "version": "0.6.0"
+    },
+    "black.kit.toybox": {
+      "version": "0.8.0"
     }
   },
   "locked": {
@@ -27,12 +27,6 @@
     "com.vrchat.core.vpm-resolver": {
       "version": "0.1.29",
       "dependencies": {}
-    },
-    "black.kit.toybox": {
-      "version": "0.7.0",
-      "dependencies": {
-        "com.vrchat.worlds": "^3.6.0"
-      }
     },
     "com.vrchat.base": {
       "version": "3.6.1",
@@ -45,8 +39,14 @@
       }
     },
     "black.kit.launchpadicons": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {}
+    },
+    "black.kit.toybox": {
+      "version": "0.8.0",
+      "dependencies": {
+        "com.vrchat.worlds": "^3.6.1"
+      }
     }
   }
 }

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,61 @@
+# ![black.kit.vrcui: 非公式の LaunchPad 風 uGUI テーマ](https://kurone-kito.github.io/vrc-ui/banner.png)
+
+Language: [🇬🇧](https://github.com/kurone-kito/vrc-ui/blob/main/README.md) | **🇯🇵**
+
+## 💡 特徴
+
+- ボタン
+- カード
+- ドロップダウン
+- スクロールバー / スライダー
+- スライドショー
+- トグル
+- 他多数！
+
+## ▶ 使い方
+
+### 1. VRChat Creator Companion (VCC) でレジストリをインポート
+
+**[VPM カタログページ](https://kurone-kito.github.io/vpm/)** にアクセスし、
+**Add to VCC** ボタンをクリックします。
+
+### 2. パッケージをプロジェクトにインポート
+
+1. VCC で "Manage Project" ボタンをクリックします。
+2. "black.kit.vrcui" パッケージを見つけ、
+   "(+) Add package" ボタンをクリックします。
+
+### 3. パッケージを使用し、楽しんでください :D
+
+(今後ドキュメントを追加予定)
+
+## 依存関係
+
+VCC を介してプロジェクトを使用する場合、
+以下の依存関係が自動的にインポートされます:
+
+- [LaunchPad Icons (black.kit.launchpadicon)](https://github.com/kurone-kito/launchpad-icons)
+- [UdonSharp Toybox (black.kit.toybox)](https://github.com/kurone-kito/udonsharp-toybox)
+
+## 貢献
+
+このリポジトリへの貢献を歓迎します！詳細については、
+[CONTRIBUTING.md](https://github.com/kurone-kito/vrc-ui/blob/main/.github/CONTRIBUTING.ja.md)
+を参照してください。
+
+## ライセンス
+
+このプロジェクトは以下のオプションでデュアルライセンスです:
+
+- [Creative Commons CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/deed.ja)
+  (既定)
+- [MIT License](https://licenses.opensource.jp/MIT/MIT.html)
+
+**既定ライセンスは Creative Commons CC BY-NC 4.0 です**。
+MIT ライセンスを適用する場合は、次の条件のいずれかを遵守してください:
+
+1. このプロジェクトは
+   **[LaunchPad Icons](https://github.com/kurone-kito/launchpad-icons)**
+   に依存しています。この依存関係を削除してください。
+2. 上記が困難な場合は、少なくとも
+   LaunchPad Icons をあなたのプロジェクト上で公開しないようにしてください。

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # ![black.kit.vrcui: Unofficial uGUI theme like the LaunchPad for VRChat worlds](https://kurone-kito.github.io/vrc-ui/banner.png)
 
+Language: **🇬🇧** | [🇯🇵](https://github.com/kurone-kito/vrc-ui/blob/main/README.ja.md)
+
 ## 💡 Features
 
-- Badges
 - Buttons
-- Panels
+- Cards
+- Dropdowns
 - Scrollbars / Sliders
-- Toast
+- Slide shows
 - Toggles
 - ... and more!
 
@@ -14,12 +16,14 @@
 
 ### 1. Import the registry via the VRChat Creator Companion (VCC)
 
-Visit the **[VPM Catalogue page](https://kurone-kito.github.io/vpm/)** and click on the **Add to VCC** button.
+Visit the **[VPM Catalogue page](https://kurone-kito.github.io/vpm/)** and
+click on the **Add to VCC** button.
 
 ### 2. Import the package to your project
 
 1. Click on the "Manage Project" button in the VCC
-2. Find the "VRCUI" package and click on the "(+) Add package" button
+2. Find the "black.kit.vrcui" package and click on the "(+) Add package"
+   button
 
 ### 3. Use the package, enjoy :D
 
@@ -35,8 +39,8 @@ dependencies:
 
 ## Contributing
 
-Welcome to contribute to this repository! For more details,
-please refer to [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+Welcome to contribute to this repository! For more details, please refer to
+[CONTRIBUTING.md](https://github.com/kurone-kito/vrc-ui/blob/main/.github/CONTRIBUTING.md).
 
 ## License
 

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -11,7 +11,6 @@ enableGlobDot: true
 features:
   weighted-suggestions: true
 globRoot: ${cwd}
-id: kurone-kito
 language: en,ja
 ignorePaths:
   - .git


### PR DESCRIPTION
This version has no new features, but includes small improvements to the sample world.

## Sample world

- 4da2bee: improved the portal
- d86d4be: moved the floor position
- a4b9c65: improved the atomic panels catalog
- 5f43092: add the text mesh pro reference

## Other updates

- 202322e: improved the README
  - added the Japanese translation
- 23bcab1: updated the dependencies
- 368b2f7: bumped the version to 0.5.1

## Project configuration

- 8a44b81: added the markdownlint configuration
- b688d7b: improved the vscode configuration
- 259af4d: improved the cspell configuration
